### PR TITLE
navbar and auth modal

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -39,7 +39,7 @@ const addHandlers = () => {
   $('body').on('submit', '.sign-up', onSignUp)
   $('body').on('submit', '.sign-in', onSignIn)
   $('body').on('submit', '.change-password', onChangePassword)
-  $('body').on('submit', '.sign-out', onSignOut)
+  $('body').on('click', '.sign-out', onSignOut)
 }
 
 module.exports = {

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -25,6 +25,7 @@ const signInSuccess = function (data) {
   $('#message').html(`<div class="alert alert-success" role="alert">You have succesfully signed in!</div>`)
   $('#message').css('text-align', 'center')
   $('form').trigger('reset')
+  $('.modal').modal('hide')
   setTimeout(() => {
     $('#message').html('')
   }, 3000
@@ -42,10 +43,14 @@ const signInSuccess = function (data) {
   const deleteFileUploadHandlebars = require('../templates/file-upload/delete-file.handlebars')
   const deleteFileUploadHTML = deleteFileUploadHandlebars()
 
+  const navHandlebars = require('../templates/nav.handlebars')
+  const navHTML = navHandlebars()
+
   $('body').append(createFileUploadHTML)
   $('body').append(updateFileUploadHTML)
   $('body').append(viewFileUploadHTML)
   $('body').append(deleteFileUploadHTML)
+  $('body').prepend(navHTML)
 
   const changePasswordUserHandlebars = require('../templates/change-password.handlebars')
   const changePasswordUserHTML = changePasswordUserHandlebars()
@@ -101,7 +106,7 @@ const signOutSuccess = function () {
   $('.view-file').remove()
   $('.delete-file').remove()
   $('.change-password').remove()
-  $('.sign-out').remove()
+  $('.navbar').remove()
 
   const homePageHandlebars = require('../templates/homepage.handlebars')
   const homePageHTML = homePageHandlebars()

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -21,4 +21,9 @@ $(() => {
   fileUploadEvents.addHandlers()
   $('body').prepend(navHTML)
   $('body').append(homePageHTML)
+  $('body').on('click', '.nav-tabs a', function (e) {
+    e.preventDefault()
+    $(this).tab('show')
+  })
+  $('.navbar').remove()
 })

--- a/assets/scripts/templates/change-password.handlebars
+++ b/assets/scripts/templates/change-password.handlebars
@@ -1,9 +1,8 @@
-<h1 data-id="" class="change-password">Change Password</h1>
 
   <form class="change-password">
     <fieldset>
       <input type="password" name="passwords[old]" autocomplete="password" placeholder="Old password" required>
       <input type="password" name="passwords[new]" autocomplete="password" placeholder="New password" required>
-      <input class="button" type="submit" value="Change Password">
+      <input class="button" type="submit" value="submit changes">
     </fieldset>
   </form>

--- a/assets/scripts/templates/homepage.handlebars
+++ b/assets/scripts/templates/homepage.handlebars
@@ -1,8 +1,6 @@
 
 <div class="jumbotron">
   <div class="jumbotron-content">
-    <i class="far fa-folder-open fa-spin"></i>
-    <i class="fab fa-firefox fa-spin"></i>
     <h1>Welcome to Foxy File!</h1>
     <p>Sign up or sign in to get started!</p>
   <div class="jumbotron-button">
@@ -16,8 +14,16 @@
 <div class="modal fade bs-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" id="sign-in-modal">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
-      {{> sign-up}}
-      {{> sign-in}}
+      <ul class="nav nav-tabs">
+        <li role="presentation" class="active"><a href="#signup">Sign Up</a></li>
+        <li role="presentation"><a href="#signin">Sign In</a></li>
+      </ul>
+      <div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="signup">{{> sign-up}}</div>
+  <div role="tabpanel" class="tab-pane" id="signin">{{> sign-in}}</div>
+</div>
+
+      </ul>
     </div>
   </div>
 </div>

--- a/assets/scripts/templates/nav.handlebars
+++ b/assets/scripts/templates/nav.handlebars
@@ -1,1 +1,25 @@
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="#">
+        <!-- Brand Logo -->
+        <i class="far fa-folder-open fa-spin"></i>
+        <i class="fab fa-firefox fa-spin"></i>
+      </a>
+    </div>
+    <!-- sign out button -->
 
+    <button type="button" class="sign-out btn btn-default navbar-btn navbar-right">Sign Out</button>
+
+    <!-- change password dropdown -->
+    <div class="sign-out-dropdown dropdown navbar-right">
+      <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        Change Password
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu1">
+      <li><a href="#">{{>change-password}}</a></li>
+    </ul>
+  </div>
+  </div>
+</nav>

--- a/assets/scripts/templates/sign-out.handlebars
+++ b/assets/scripts/templates/sign-out.handlebars
@@ -1,8 +1,6 @@
-
-<h1 data-id="" class="sign-out">Sign Out</h1>
-
+<!--
 <form class="sign-out">
   <fieldset>
     <input class="button" type="submit" value="Sign Out">
   </fieldset>
-</form>
+</form> -->

--- a/assets/styles/dylan.scss
+++ b/assets/styles/dylan.scss
@@ -26,3 +26,15 @@ body {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+
+.modal-content {
+  padding: 0 40px 70px 40px;
+}
+
+.sign-out-button {
+  margin-right: 10px;
+}
+
+.sign-out-dropdown {
+  margin-top: 8px;
+}


### PR DESCRIPTION
events.js:
  changed 'submit' to 'click' in addhandlers so bootstrap button works.

ui.js:
  signInSuccess now closes modal
  navbar is now PREPENDED to body on signInSuccess
  signOutSuccess removes navbar

change-password.handlebar:
  changed value to submit changes

homepage.handlebars:
  put tabs for sign in and signup in the auth modal

nav.handlebars:
  created a navbar with a brand logo and embedded the signout and changepassword
  into the navbar.
  changepassword is now a dropdown and signout is a button
  (WOULD LIKE TO MAKE NAV BAR FIXED BUT MESSAGES SEEM TO MESS IT UP)

sign-out.handlebars:
  commented out because I don't think we need them anymore.

index.js:
  on page load the navbar is not displayed
  added function so u can click and change tabs

dylan.scsss:
  added padding to modal content
  pushed over sign out button slightly
  aligned change password dropdown with sign-out button