### PR TITLE
Ui

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -2,6 +2,7 @@
 const getFormFields = require('../../../lib/get-form-fields')
 const ui = require('./ui')
 const api = require('./api')
+const fileEvents = require('../fileupload/fileUploadEvents')
 
 const onSignUp = function (event) {
   event.preventDefault()
@@ -17,6 +18,7 @@ const onSignIn = function (event) {
   const data = getFormFields(event.target)
   api.signIn(data)
     .then(ui.signInSuccess)
+    .then(() => { fileEvents.onGetFileUploadNoEvent() })
     .catch(ui.signInFailure)
 }
 

--- a/assets/scripts/fileupload/fileuploadapi.js
+++ b/assets/scripts/fileupload/fileuploadapi.js
@@ -29,10 +29,9 @@ const updateFileUpload = (data) => {
 
 const deleteFileUpload = function (data) {
   return $.ajax({
-    url: config.apiUrl + `/fileupload/` + data.id,
+    url: config.apiUrl + `/fileuploads/` + data.fileupload.id,
     method: 'DELETE',
     headers: {
-      contentType: 'application/json',
       Authorization: 'Token token=' + store.user.token
     },
     data: data

--- a/assets/scripts/fileupload/fileuploadapi.js
+++ b/assets/scripts/fileupload/fileuploadapi.js
@@ -18,10 +18,9 @@ const createFileUpload = function (formData) {
 
 const updateFileUpload = (data) => {
   return $.ajax({
-    url: config.apiUrl + `/fileupload/` + data.id,
+    url: config.apiUrl + `/fileuploads/` + data.fileupload.id,
     method: 'PATCH',
     headers: {
-      contentType: 'application/json',
       Authorization: 'Token token=' + store.user.token
     },
     data: data

--- a/assets/scripts/fileupload/fileuploadevents.js
+++ b/assets/scripts/fileupload/fileuploadevents.js
@@ -41,6 +41,13 @@ const onGetFileUpload = (event) => {
     // .catch(ui.)
 }
 
+const deleter = (e) => {
+  e.preventDefault()
+  console.log('delete ')
+  const data = {fileupload: { id: $(e.target).children().attr('data-id') }}
+  console.log('item to delete has id of', data)
+  api.deleteFileUpload(data)
+}
 
 const onGetFileUploadNoEvent = () => {
   // const data = getFormFields(event.target)
@@ -54,6 +61,7 @@ const addHandlers = () => {
   $('body').on('submit', '.view-file', onGetFileUpload)
   $('body').on('submit', '.update-file', onUpdateFileUpload)
   $('body').on('submit', '.delete-file', onDeleteFileUpload)
+  $('body').on('submit', '.form-results .delete-single-file', deleter)
 }
 
 module.exports = {

--- a/assets/scripts/fileupload/fileuploadevents.js
+++ b/assets/scripts/fileupload/fileuploadevents.js
@@ -8,15 +8,18 @@ const onCreateFileUpload = function (event) {
   const formData = new FormData(event.target)
   console.log('form data in submit is: ', formData)
   api.createFileUpload(formData)
-    // .then(ui.)
+    .then(ui.createFileUploadSuccess)
     // .catch(ui.)
 }
 
 const onUpdateFileUpload = function (event) {
   event.preventDefault()
   const data = getFormFields(event.target)
+  data.fileupload.tag = data.fileupload.tag.split(', ')
+  console.log(data)
   api.updateFileUpload(data)
-    // .then(ui.)
+    .then((data) => { console.log(data) })
+    .then(onGetFileUploadNoEvent)
     // .catch(ui.)
 }
 
@@ -37,11 +40,21 @@ const onGetFileUpload = (event) => {
     // .catch(ui.)
 }
 
+
+const onGetFileUploadNoEvent = () => {
+  // const data = getFormFields(event.target)
+  api.getFileUpload()
+    .then(ui.getFileUploadSuccess)
+    // .catch(ui.)
+}
+
 const addHandlers = () => {
   $('body').on('submit', '.create-file', onCreateFileUpload)
   $('body').on('submit', '.view-file', onGetFileUpload)
+  $('body').on('submit', '.update-file', onUpdateFileUpload)
 }
 
 module.exports = {
-  addHandlers
+  addHandlers,
+  onGetFileUploadNoEvent
 }

--- a/assets/scripts/fileupload/fileuploadevents.js
+++ b/assets/scripts/fileupload/fileuploadevents.js
@@ -26,6 +26,7 @@ const onUpdateFileUpload = function (event) {
 const onDeleteFileUpload = (event) => {
   event.preventDefault()
   const data = getFormFields(event.target)
+  console.log(data)
   api.deleteFileUpload(data)
     // .then(ui.)
     // .then(api.)
@@ -52,6 +53,7 @@ const addHandlers = () => {
   $('body').on('submit', '.create-file', onCreateFileUpload)
   $('body').on('submit', '.view-file', onGetFileUpload)
   $('body').on('submit', '.update-file', onUpdateFileUpload)
+  $('body').on('submit', '.delete-file', onDeleteFileUpload)
 }
 
 module.exports = {

--- a/assets/scripts/fileupload/fileuploadui.js
+++ b/assets/scripts/fileupload/fileuploadui.js
@@ -2,8 +2,13 @@
 // const store = require('../store')
 
 const createFileUploadSuccess = function (data) {
+  console.log(data)
+  $('#message').html(`<div class="alert alert-success" role="alert"><p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p></div>`)
+  $('.all-files').append(`<p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p>`)
+  $('#message').css('text-align', 'center')
+  $('form').trigger('reset')
   setTimeout(() => {
-    $('#message').html('')
+    $('#message').html(``)
   }, 3000
   )
 }
@@ -45,10 +50,12 @@ const deleteFileUploadFailure = function () {
 
 const getFileUploadSuccess = function (data) {
   console.log(data)
-  let resultsHtml = ''
+  $('.all-files').remove()
+  let resultsHtml = '<div class="all-files">'
   data.uploads.forEach((result) => {
     resultsHtml = resultsHtml + `<p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p>`
   })
+  resultsHtml = resultsHtml + '</div>'
   $('form.view-file').append(resultsHtml)
   setTimeout(() => {
     $('#message').html('')

--- a/assets/scripts/fileupload/fileuploadui.js
+++ b/assets/scripts/fileupload/fileuploadui.js
@@ -1,9 +1,10 @@
 'use strict'
-// const store = require('../store')
+const store = require('../store')
+const moment = require('moment')
 
 const createFileUploadSuccess = function (data) {
   console.log(data)
-  $('#message').html(`<div class="alert alert-success" role="alert"><p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p></div>`)
+  $('#message').html(`<div class="alert alert-success" role="alert"><p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p><form><input type="submit" value="Delete"></form></div>`)
   $('.all-files').append(`<p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p>`)
   $('#message').css('text-align', 'center')
   $('form').trigger('reset')
@@ -34,7 +35,9 @@ const updateFileUploadFailure = function () {
   )
 }
 
-const deleteFileUploadSuccess = function () {
+const deleteFileUploadSuccess = function (data) {
+  console.log(data)
+  $('#message').html('You successfully deleted your file!')
   setTimeout(() => {
     $('#message').html('')
   }, 3000
@@ -50,12 +53,25 @@ const deleteFileUploadFailure = function () {
 
 const getFileUploadSuccess = function (data) {
   console.log(data)
+  $('.my-files').remove()
   $('.all-files').remove()
-  let resultsHtml = '<div class="all-files">'
+  const myFiles = []
+  data.uploads.forEach((file) => {
+    if (file.owner === store.user._id) {
+      myFiles.push(file)
+    }
+  })
+  console.log(myFiles)
+  let myResultsHtml = '<div class="my-files col-md-6"><h3>My Files</h3>'
+  myFiles.forEach((result) => {
+    myResultsHtml = myResultsHtml + `<p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p><p>Tags: ${result.tag}</p><form><input type="submit" value="Delete"></form>`
+  })
+  let resultsHtml = '<div class="all-files col-md-6"><h3>All Files</h3>'
   data.uploads.forEach((result) => {
-    resultsHtml = resultsHtml + `<p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p>`
+    resultsHtml = resultsHtml + `<p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p><p>Tags: ${result.tag}</p>`
   })
   resultsHtml = resultsHtml + '</div>'
+  $('form.view-file').append(myResultsHtml)
   $('form.view-file').append(resultsHtml)
   setTimeout(() => {
     $('#message').html('')

--- a/assets/scripts/fileupload/fileuploadui.js
+++ b/assets/scripts/fileupload/fileuploadui.js
@@ -4,8 +4,9 @@ const moment = require('moment')
 
 const createFileUploadSuccess = function (data) {
   console.log(data)
-  $('#message').html(`<div class="alert alert-success" role="alert"><p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p><form><input type="submit" value="Delete"></form></div>`)
+  $('#message').html(`<div class="alert alert-success" role="alert"><p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p><form><input data-id="${data.fileupload._id}" type="submit" value="Delete"></form></div>`)
   $('.all-files').append(`<p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p>`)
+  $('.my-files').append(`<div id="${data.fileupload._id}"><p><a href="${data.fileupload.url}" download="${data.fileupload.title}">Name: ${data.fileupload.title}</a></p><p>Owner: ${data.fileupload.owner}</p><p>Created: ${data.fileupload.createdAt}</p><p>Updated: ${data.fileupload.updatedAt}</p><p>Tags: ${data.fileupload.tag}</p><form class="delete-single-file"><input  data-id="${data.fileupload._id}" type="submit" value="Delete"></form></div>`)
   $('#message').css('text-align', 'center')
   $('form').trigger('reset')
   setTimeout(() => {
@@ -64,15 +65,15 @@ const getFileUploadSuccess = function (data) {
   console.log(myFiles)
   let myResultsHtml = '<div class="my-files col-md-6"><h3>My Files</h3>'
   myFiles.forEach((result) => {
-    myResultsHtml = myResultsHtml + `<p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p><p>Tags: ${result.tag}</p><form><input type="submit" value="Delete"></form>`
+    myResultsHtml = myResultsHtml + `<div id="${result._id}"><p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p><p>Tags: ${result.tag}</p><form class="delete-single-file"><input  data-id="${result._id}" type="submit" value="Delete"></form></div>`
   })
   let resultsHtml = '<div class="all-files col-md-6"><h3>All Files</h3>'
   data.uploads.forEach((result) => {
     resultsHtml = resultsHtml + `<p><a href="${result.url}" download="${result.title}">Name: ${result.title}</a></p><p>Owner: ${result.owner}</p><p>Created: ${result.createdAt}</p><p>Updated: ${result.updatedAt}</p><p>Tags: ${result.tag}</p>`
   })
   resultsHtml = resultsHtml + '</div>'
-  $('form.view-file').append(myResultsHtml)
-  $('form.view-file').append(resultsHtml)
+  $('.form-results').append(myResultsHtml)
+  $('.form-results').append(resultsHtml)
   setTimeout(() => {
     $('#message').html('')
   }, 3000

--- a/assets/scripts/templates/file-upload/delete-file.handlebars
+++ b/assets/scripts/templates/file-upload/delete-file.handlebars
@@ -2,6 +2,8 @@
 
   <form class="delete-file">
     <fieldset>
+      <input type="text" name="fileupload[id]">
+
       <input class="button" type="submit" value="Delete File">
     </fieldset>
   </form>

--- a/assets/scripts/templates/file-upload/update-file.handlebars
+++ b/assets/scripts/templates/file-upload/update-file.handlebars
@@ -2,9 +2,11 @@
 
   <form class="update-file">
     <fieldset>
+      <input type="text" name="fileupload[id]" autocomplete="id" placeholder="file ID" required>
+
       <input type="text" name="fileupload[title]" autocomplete="title" placeholder="New file name" required>
 
-      <input type="text" name="fileupload[tags]" autocomplete="tags" placeholder="Tags (ex. cat, dog)">
+      <input type="text" name="fileupload[tag]" autocomplete="tags" placeholder="Tags (ex. cat, dog)">
 
       <input class="button" type="submit" value="Update File">
     </fieldset>

--- a/assets/scripts/templates/file-upload/view-file.handlebars
+++ b/assets/scripts/templates/file-upload/view-file.handlebars
@@ -7,3 +7,4 @@
       <input class="button" type="submit" value="View File">
     </fieldset>
   </form>
+  <div class="form-results"></div>


### PR DESCRIPTION
Adds update functionality as well as view all 
After login a user now automatically will see all files in the database.
If a user fills out the update form they can update the name and tags in
the database for that particular entry. currently the user needs to
enter the mongo ID for the file they want to update, next rendition
should automatically populate this for them. next steps: add delete for
crud and the ability to GET a single item.

Adds file delete  
Delete now not only deletes the mongo version of the file, but also
deletes the S3 version. Most noteable change is on the S3 bucket to
actually allow delete as an action.

Adds more styling to GET results  
Results now go through a forEach loop to sort your files into a separate
array which is put in using the same format but with a currently
non-functional form for deleting the file.

Adds Buttons to delete Files  
"my files" now includes a delet button under each entry, button has a
data id that corresponds to the database id which will communicate with
the express API, deleting the file from both the mongo DB and also the
s3 bucket. Also adds a div to hold the results of view file instead of
appending them to the form.
a20421d
